### PR TITLE
Fix incorrect array length causing undefined errors

### DIFF
--- a/src/angular-block-ui/directive.js
+++ b/src/angular-block-ui/directive.js
@@ -41,7 +41,7 @@ angular.module('blockUI').directive('blockUi', function(blockUI, blockUIConfig, 
 
         // Create the blockUI instance
 
-        var instanceId = !$attrs.blockUi ? $scope.$id : $attrs.blockUi;
+        var instanceId = !$attrs.blockUi ? '_' + $scope.$id : $attrs.blockUi;
 
         srvInstance = blockUI.instances.get(instanceId);
 


### PR DESCRIPTION
$scope.$id can return valid numeric values. This line will cause an issue on the array length:
instance = instances[id] = new BlockUI(id);

i.e. instances[200] would result to an array length of 201
