### PR TITLE
Fix(service): `this` context is not `self`

### DIFF
--- a/src/angular-block-ui/service.js
+++ b/src/angular-block-ui/service.js
@@ -52,7 +52,7 @@ angular.module('blockUI').factory('blockUI', function(blockUIConfig, $timeout, b
       state.blockCount = Math.max(0, --state.blockCount);
 
       if (state.blockCount === 0) {
-        this.reset(true);
+        self.reset(true);
       }
     };
 


### PR DESCRIPTION
Fixed #11 and #15

The reference `this` was different when `blockUi.stop` was called via a timeout or callback (where `window` is passed as the context).  Replaced it with the scoped `this` reference `self`.
