### PR TITLE
Remove 'src' from bower ignored files.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,6 @@
     "node_modules",
     "bower_components",
     "gulp-tasks",
-    "src",
     "dest",
     "/build-config.js",
     "/gulpfile.js",


### PR DESCRIPTION
It would be cool to keep the 'src' files as for some users (like us for wishtack.com), we merge most of our dependencies source code in one file that we minify. We can't do that with the 'dest' files due to the 'sourceMappingURL' that was added.

Thanks !
